### PR TITLE
Enabled gzip compression in API

### DIFF
--- a/source/api/.chalice/config.json
+++ b/source/api/.chalice/config.json
@@ -9,7 +9,8 @@
     "dev": {
       "manage_iam_role": false,
       "iam_role_arn": "arn:aws:iam::999999999999:role/DummyRoleToBeReplaced",
-      "api_gateway_stage": "api"
+      "api_gateway_stage": "api",
+      "minimum_compression_size": 5242880
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added `minimum_compression_size` setting in Chalice config file, this enables gzip compression in the API Gw stage. According [to the docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-openapi-minimum-compression-size.html) to enable compression the number must be an integer greater than 1 and smaller than 10485760 bytes.

I have set 5.2MB because that's the amount shown in the example of the documentation, this means payloads smaller than that won't be compressed. I am open to change the number if you have any other size in mind (could also be 1 byte so all payloads are compressed).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
