### PR TITLE
Add StackName as prefix to managed resurces names

### DIFF
--- a/.github/workflows/nightly-workflow.yml
+++ b/.github/workflows/nightly-workflow.yml
@@ -109,8 +109,8 @@ jobs:
           aws cloudformation delete-stack --stack-name $SFM_STACK_NAME
       - name: Delete SFM created resources
         run: |
-          aws lambda delete-function --function-name $FILESYSTEM_ID-manager-lambda
-          aws iam detach-role-policy --role-name $FILESYSTEM_ID-manager-role --policy-arn arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess
-          aws iam detach-role-policy --role-name $FILESYSTEM_ID-manager-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-          aws iam detach-role-policy --role-name $FILESYSTEM_ID-manager-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-          aws iam delete-role --role-name $FILESYSTEM_ID-manager-role
+          aws lambda delete-function --function-name $SFM_STACK_NAME-EFSFileManager-$FILESYSTEM_ID-manager-lambda
+          aws iam detach-role-policy --role-name $SFM_STACK_NAME-$FILESYSTEM_ID-manager-role --policy-arn arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess
+          aws iam detach-role-policy --role-name $SFM_STACK_NAME-$FILESYSTEM_ID-manager-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+          aws iam detach-role-policy --role-name $SFM_STACK_NAME-$FILESYSTEM_ID-manager-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          aws iam delete-role --role-name $SFM_STACK_NAME-$FILESYSTEM_ID-manager-role

--- a/deployment/efs-file-manager.yaml
+++ b/deployment/efs-file-manager.yaml
@@ -79,7 +79,7 @@ Resources:
                 Action:
                   - "iam:PassRole"
                 Resource:
-                  - "arn:aws:iam::*:role/fs-*-manager-role"
+                  - !Sub "arn:aws:iam::*:role/${AWS::StackName}-fs-*-manager-role"
                 Condition:
                   StringEquals:
                     iam:PassedToService: lambda.amazonaws.com
@@ -87,7 +87,7 @@ Resources:
                 Action: 
                   - "iam:GetRole"
                 Resource:
-                  - "arn:aws:iam::*:role/fs-*-manager-role"
+                  - !Sub  "arn:aws:iam::*:role/${AWS::StackName}-fs-*-manager-role"
               - Effect: Allow
                 Action:
                   - "elasticfilesystem:DeleteAccessPoint"
@@ -100,13 +100,13 @@ Resources:
                   - "iam:DetachRolePolicy"
                   - "iam:AttachRolePolicy"
                   - "iam:DeleteRole"
-                Resource: "arn:aws:iam::*:role/fs-*-manager-role"
+                Resource: !Sub "arn:aws:iam::*:role/${AWS::StackName}-fs-*-manager-role"
               - Effect: Allow
                 Action:
                   - "lambda:InvokeFunction"
                   - "lambda:GetFunction"
                   - "lambda:DeleteFunction"
-                Resource: "arn:aws:lambda:*:*:function:fs-*-manager-lambda"
+                Resource: !Sub "arn:aws:lambda:*:*:function:${AWS::StackName}-EFSFileManager-fs-*-manager-lambda"
               - Effect: Allow
                 Action:
                   - "cloudformation:CreateStack"

--- a/source/api/app.py
+++ b/source/api/app.py
@@ -35,7 +35,7 @@ cfn = boto3.client('cloudformation', config=config)
 # Helper functions
 
 def proxy_operation_to_efs_lambda(filesystem_id, event):
-    lambda_name = '{filesystem}-manager-lambda'.format(filesystem=filesystem_id)
+    lambda_name = '{stack_prefix}-EFSFileManager-{filesystem}-manager-lambda'.format(stack_prefix=stack_prefix,filesystem=filesystem_id)
     try:
         response = serverless.invoke(
             InvocationType='RequestResponse',

--- a/source/api/chalicelib/file-manager-ap-lambda.template
+++ b/source/api/chalicelib/file-manager-ap-lambda.template
@@ -14,6 +14,8 @@ Parameters:
     Type: String
   VpcConfigSubnetIds:
     Type: String
+  StackPrefix:
+    Type: String
 
 Resources:
   ManagedAccessPoint:
@@ -231,7 +233,7 @@ Resources:
       FileSystemConfigs:
         - Arn: !GetAtt ManagedAccessPoint.Arn
           LocalMountPath: "/mnt/efs"
-      FunctionName: !Sub "${FileSystemId}-manager-lambda"
+      FunctionName: !Sub "${StackPrefix}-EFSFileManager-${FileSystemId}-manager-lambda"
       Handler: "index.lambda_handler"
       MemorySize: 512
       PackageType: "Zip"


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Added main stack name as prefix of the names of resources created via CloudFormation when onobarding a file systems so that they match the rest of resources. This will help Customers find the CloudWatch Log groups to clean up when they delete the stack.

@brandold I have tested the stack and it works but didn't test the changes to the `nightly-workflow.yml` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
